### PR TITLE
feat: rewrite SKILL.md to use jules_cli shell commands

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -1,59 +1,50 @@
 ---
 name: jules-skill
-description: "Interaction with Jules (Google AI coding agent) via MCP tools. Use this skill when you need to: (1) Check the status or progress of a Jules session, (2) Retrieve questions or feedback requests from Jules, (3) Approve a plan or send a message to a session, (4) List all active or past Jules sessions, (5) Create new Jules sessions."
+description: "Use this skill whenever Jules (Google's async AI coding agent) is mentioned or implied. Triggers include: starting a new Jules coding task (\"kick off\", \"create a session\"), checking Jules session status or progress, reading a message Jules left, approving or rejecting a Jules plan, replying to Jules mid-task, and scanning for sessions in states like AWAITING_PLAN_APPROVAL or AWAITING_USER_FEEDBACK. Also triggers on bare Jules session IDs (long numeric strings) or any request to monitor, manage, or respond to Jules activity across repos."
 ---
 
 # Jules Skill
 
 ## Overview
 
-This skill drives Jules via the **`jules-api-mcp`** MCP server. All API calls are made through MCP tools — no Python scripts needed.
+This skill drives Jules via the **`jules_cli`** CLI. All API calls are made through shell commands — no MCP server needed.
 
 Jules is an **async coding agent** powered by Gemini 2.5 Pro. It clones your repo into a secure Google Cloud VM, generates a multi-step plan, executes it autonomously, and optionally opens a PR.
 
-## Setup
+## Prerequisites
 
-Install the MCP server and add it to your MCP client config:
+`JULES_API_KEY` must be available. Set it via one of:
 
-```json
-{
-  "mcpServers": {
-    "jules": {
-      "command": "node",
-      "args": ["/path/to/jules-api-mcp/dist/index.js"],
-      "env": {
-        "JULES_API_KEY": "<your-key>"
-      }
-    }
-  }
-}
+1. **Environment variable**: `export JULES_API_KEY=<your-key>`
+2. **Interactive setup**: `jules_cli setup` (prompts for key, saves to `~/.config/jules/config.json`)
+
+## CLI Command Reference
+
+| Command | Description |
+|---------|-------------|
+| `jules_cli list [--json]` | List all Jules sessions |
+| `jules_cli show <id> [--json]` | Get session details and state |
+| `jules_cli create --repo owner/repo --prompt "..." [--auto-pr] [--approve-plan] [--json]` | Create a new Jules session |
+| `jules_cli approve <id>` | Approve Jules's plan to proceed |
+| `jules_cli send <id> --message "..." [--json]` | Send feedback or instructions |
+| `jules_cli last-msg <id> [--json]` | Jules's latest outbound message |
+| `jules_cli pr-url <id>` | Get the PR URL from a completed session |
+| `jules_cli setup` | Interactive API key setup |
+
+## Most Common Pattern: Sweep AWAITING Sessions
+
+When the user mentions Jules activity or asks you to "check Jules", always start here:
+
+```
+1. jules_cli list --json
+2. Filter: state contains "AWAITING"
+3. For each hit:
+   - jules_cli last-msg <id>  → read Jules's question/plan
+   - AWAITING_PLAN_APPROVAL  → jules_cli approve <id>  (or jules_cli send <id> --message "..." to cancel)
+   - AWAITING_USER_FEEDBACK  → jules_cli send <id> --message "your reply"
 ```
 
-Or via npx (once published to npm):
-```json
-{
-  "mcpServers": {
-    "jules": {
-      "command": "npx",
-      "args": ["jules-api-mcp"],
-      "env": { "JULES_API_KEY": "<your-key>" }
-    }
-  }
-}
-```
-
-## Available MCP Tools
-
-| Tool | Description |
-|------|-------------|
-| `list_sessions` | List all Jules sessions |
-| `get_session` | Get session details and state |
-| `create_session` | Create a new Jules session |
-| `approve_plan` | Approve Jules's plan to proceed |
-| `send_message` | Send feedback or instructions |
-| `list_activities` | Full activity timeline |
-| `get_last_message` | Jules's latest outbound message |
-| `get_pr_url` | Get the PR URL from a completed session |
+If the user says "jules #<ID> updated" or pastes a session ID, go straight to `jules_cli show <id>` then `jules_cli last-msg <id>`.
 
 ## Task-Based Workflow
 
@@ -61,18 +52,18 @@ Or via npx (once published to npm):
 
 **Autopilot** (Jules creates PR automatically):
 ```
-create_session(repo="owner/repo", prompt="Your task", automation_mode="AUTO_CREATE_PR")
+jules_cli create --repo owner/repo --prompt "Your task" --auto-pr
 ```
 
 **Interactive** (review plan before execution):
 ```
-create_session(repo="owner/repo", prompt="Your task", require_plan_approval=true)
+jules_cli create --repo owner/repo --prompt "Your task" --approve-plan
 ```
 
 ### 2. Listing & Checking Sessions
 ```
-list_sessions()
-get_session(session_id="<ID>")
+jules_cli list
+jules_cli show <id>
 ```
 
 States:
@@ -86,32 +77,32 @@ States:
 ### 3. Responding to Jules
 ```
 # Approve a plan
-approve_plan(session_id="<ID>")
+jules_cli approve <id>
 
 # Answer a question or send instructions
-send_message(session_id="<ID>", message="Your reply here")
+jules_cli send <id> --message "Your reply here"
 
 # Read Jules's latest message first
-get_last_message(session_id="<ID>")
+jules_cli last-msg <id>
 ```
 
 ### 4. Getting the PR
 ```
-get_pr_url(session_id="<ID>")
+jules_cli pr-url <id>
 ```
 
 ## Autonomous Monitoring Loop
 
 ```
-1. list_sessions() → filter where state starts with "AWAITING"
+1. jules_cli list --json  → filter where state starts with "AWAITING"
 2. For each AWAITING session:
-   a. get_session() to confirm current state
-   b. AWAITING_PLAN_APPROVAL → get_last_message() to review → approve_plan() or send_message() to cancel
-   c. AWAITING_USER_FEEDBACK → get_last_message() to read Jules's question → send_message() with reply
+   a. jules_cli show <id>  to confirm current state
+   b. AWAITING_PLAN_APPROVAL → jules_cli last-msg <id> to review → jules_cli approve <id> or jules_cli send <id> --message "..." to cancel
+   c. AWAITING_USER_FEEDBACK → jules_cli last-msg <id> to read Jules's question → jules_cli send <id> --message "reply"
 3. Repeat on a schedule (e.g. every 10–15 min)
 ```
 
-> **`get_last_message` caveat**: returns Jules's last *outbound* message, which may be stale.
+> **`last-msg` caveat**: returns Jules's last *outbound* message, which may be stale.
 > Always check `state` first — if state just changed to `AWAITING_USER_FEEDBACK`, the message is fresh.
 > If you already replied and state is still `AWAITING`, Jules hasn't processed your answer yet.
 
@@ -125,7 +116,7 @@ get_pr_url(session_id="<ID>")
 | Jules asks "class method or standalone function?" | Match the existing file structure |
 | Jules asks about trailing whitespace preservation | No need to preserve — clean output preferred |
 | Jules asks about benchmark scripts | Not needed — correctness changes don't need benchmarks |
-| Jules's plan matches the task description | `approve_plan()` |
+| Jules's plan matches the task description | `jules_cli approve <id>` |
 | Two sessions targeting the same file+lines | Approve the first, tell the second to stand down |
 | Jules asks to confirm PR creation | Reply: "Yes, create the PR now." |
 | Jules asks "do you approve this approach?" for no-op | Reply: "Yes, approved." |
@@ -134,7 +125,7 @@ get_pr_url(session_id="<ID>")
 
 - **Be specific**: Include file names, function names, and expected outcomes.
 - **Scope tightly**: Jules works best on self-contained tasks.
-- **Use `require_plan_approval=true`** for non-trivial or risky tasks.
+- **Use `--approve-plan`** for non-trivial or risky tasks.
 - **Always append constraints** relevant to your project:
   ```
   Constraints:
@@ -166,5 +157,5 @@ Jules automatically reads `AGENTS.md` from the repo root. Keep it up to date wit
 
 ## Resources
 
-- **MCP Server**: [github.com/GreyC/jules-api-mcp](https://github.com/GreyC/jules-api-mcp)
+- **jules_cli**: `npx jules_cli` or install from `packages/cli`
 - **Jules**: [jules.google.com](https://jules.google.com)


### PR DESCRIPTION
Closes #4. Part of #1.

## Changes

- Removed MCP server setup section and MCP tools table
- Added **Prerequisites** section (`JULES_API_KEY` env var or `jules_cli setup`)
- Replaced MCP tools table with `jules_cli` command reference
- Rewrote all workflow examples (sweep loop, session creation, plan approval, feedback) using shell commands
- Updated decision heuristics table to use `jules_cli approve <id>` syntax
- Updated Prompt Engineering Tips (`--approve-plan` flag instead of `require_plan_approval=true`)
- Updated Resources section (removed MCP server link, added `jules_cli` install note)

## Command mapping

| Before (MCP) | After (CLI) |
|---|---|
| `list_sessions()` | `jules_cli list --json` |
| `get_session(session_id)` | `jules_cli show <id> --json` |
| `create_session(...)` | `jules_cli create --repo ... --prompt "..."` |
| `approve_plan(session_id)` | `jules_cli approve <id>` |
| `send_message(session_id, message)` | `jules_cli send <id> --message "..."` |
| `get_last_message(session_id)` | `jules_cli last-msg <id>` |
| `get_pr_url(session_id)` | `jules_cli pr-url <id>` |

generated by CC