### PR TITLE
feat: publish jules-cli as @l0r3x/jules-cli on npm

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,31 @@
+name: Publish @l0r3x/jules-cli
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: self-hosted
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Install dependencies
+        working-directory: packages/cli
+        run: npm install
+
+      - name: Build
+        working-directory: packages/cli
+        run: npm run build
+
+      - name: Publish
+        working-directory: packages/cli
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/SKILL.md
+++ b/SKILL.md
@@ -157,5 +157,5 @@ Jules automatically reads `AGENTS.md` from the repo root. Keep it up to date wit
 
 ## Resources
 
-- **jules_cli**: `npx jules_cli` or install from `packages/cli`
+- **jules_cli**: `npm install -g @l0r3x/jules-cli` or `npx @l0r3x/jules-cli`
 - **Jules**: [jules.google.com](https://jules.google.com)

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,10 +1,19 @@
 {
-  "name": "jules_cli",
+  "name": "@l0r3x/jules-cli",
   "version": "0.1.0",
-  "description": "Jules CLI",
+  "description": "Jules CLI — manage Jules (Google's async AI coding agent) from the command line",
   "main": "dist/index.js",
   "bin": {
     "jules_cli": "./dist/index.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/GreyC/jules-skill.git",
+    "directory": "packages/cli"
+  },
+  "license": "MIT",
+  "publishConfig": {
+    "access": "public"
   },
   "files": [
     "dist"


### PR DESCRIPTION
## Summary

- Renames package from `jules_cli` to `@l0r3x/jules-cli` (scoped, public)
- Adds `.github/workflows/publish.yml` — triggers on `v*` tags, runs on self-hosted runner (`jules-vps`), builds and publishes to npm using `NPM_TOKEN` secret
- Updates `SKILL.md` resources section to reference the npm package

## Test plan

- [ ] Add `NPM_TOKEN` secret to repo settings (Settings → Secrets → Actions)
- [ ] Merge this PR then push a `v0.1.0` tag: `git tag v0.1.0 && git push origin v0.1.0`
- [ ] Verify package appears at `npmjs.com/package/@l0r3x/jules-cli`
- [ ] Test: `npx @l0r3x/jules-cli list`

generated by CC